### PR TITLE
require iat in PoP

### DIFF
--- a/draft-ietf-oauth-attestation-based-client-auth.md
+++ b/draft-ietf-oauth-attestation-based-client-auth.md
@@ -627,6 +627,7 @@ This section requests registration of the following scheme in the "Hypertext Tra
 # Document History
 
 -07
+
 * require `iat` in Client Attestation PoP JWT
 
 -06


### PR DESCRIPTION
The draft has a lot to say about utilizing `iat` and `jti` for replay detection, to that end the `iat` must be present.

closes #133