### PR TITLE
OAuth 2 artefact binding

### DIFF
--- a/draft-ietf-oauth-attestation-based-client-auth.md
+++ b/draft-ietf-oauth-attestation-based-client-auth.md
@@ -536,7 +536,7 @@ Implementers should be aware that the design of this authentication mechanism de
 
 Authorization servers issuing a refresh token in response to a token request using the client attestation mechanism as defined by this draft MUST bind the refresh token to the Client Instance and its associated public key, and NOT just the client as specified in section 6 {{RFC6749}}. To prove this binding, the Client Instance MUST use the client attestation mechanism when refreshing an access token. The client MUST also use the same key that was present in the "cnf" claim of the client attestation that was used when the refresh token was issued.
 
-## Binding of OAuth protocol artefacts
+## Binding of OAuth protocol artifacts
 
 Authorization servers using Attestation-Based Client Authentication are RECOMMENDED to bind relevant protocol artifacts to the Client Instance and its associated public key where possible, and NOT just the client as specified in section 6 {{RFC6749}}. Examples of these artifacts include but are not limited to:
 

--- a/draft-ietf-oauth-attestation-based-client-auth.md
+++ b/draft-ietf-oauth-attestation-based-client-auth.md
@@ -69,6 +69,9 @@ informative:
   ARF:
   	title: "The European Digital Identity Wallet Architecture and Reference Framework"
   SD-JWT: I-D.ietf-oauth-selective-disclosure-jwt
+  CIBA:
+    title: OpenID Connect Client-Initiated Backchannel Authentication Flow - Core 1.0
+    target: https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html
 
 
 --- abstract
@@ -532,6 +535,15 @@ Implementers should be aware that the design of this authentication mechanism de
 ## Refresh token binding
 
 Authorization servers issuing a refresh token in response to a token request using the client attestation mechanism as defined by this draft MUST bind the refresh token to the Client Instance and its associated public key, and NOT just the client as specified in section 6 {{RFC6749}}. To prove this binding, the Client Instance MUST use the client attestation mechanism when refreshing an access token. The client MUST also use the same key that was present in the "cnf" claim of the client attestation that was used when the refresh token was issued.
+
+## Binding of OAuth protocol artefacts
+
+Authorization servers where possible are RECOMMENDED to bind relevant protocol artefacts to the Client Instance and its associated public key, and NOT just the client as specified in section 6 {{RFC6749}}. Examples of these artefacts include but are not limited to:
+
+- The authorization_code as specified in section 4.1 {{RFC6749}}.
+- The auth_req_id as specified in section 7.3 {{CIBA}}.
+
+How this binding is established and then proven is specific to the protocol artifact. For example establishing binding to an authorization_code involves the client instance using client attestation in the authorization request, and proving binding of the authorization_code to the Client Instance involves using the client attestation mechanism to authenticate at the token endpoint using an authorization code grant.
 
 ## Web Server Default Maximum HTTP Header Sizes
 

--- a/draft-ietf-oauth-attestation-based-client-auth.md
+++ b/draft-ietf-oauth-attestation-based-client-auth.md
@@ -543,7 +543,7 @@ Authorization servers where possible are RECOMMENDED to bind relevant protocol a
 - The authorization_code as specified in section 4.1 {{RFC6749}}.
 - The auth_req_id as specified in section 7.3 {{CIBA}}.
 
-How this binding is established and then proven is specific to the protocol artifact. For example establishing binding to an authorization_code involves the client instance using client attestation in the authorization request, and proving binding of the authorization_code to the Client Instance involves using the client attestation mechanism to authenticate at the token endpoint using an authorization code grant.
+How this binding is established and then proven is specific to the protocol artefact. For example establishing binding to an authorization_code involves the client instance using client attestation in the authorization request, and proving binding of the authorization_code to the Client Instance involves using the client attestation mechanism to authenticate at the token endpoint using an authorization code grant.
 
 ## Web Server Default Maximum HTTP Header Sizes
 

--- a/draft-ietf-oauth-attestation-based-client-auth.md
+++ b/draft-ietf-oauth-attestation-based-client-auth.md
@@ -543,7 +543,7 @@ Authorization servers using Attestation-Based Client Authentication are RECOMMEN
 - The authorization_code as specified in section 4.1 {{RFC6749}}.
 - The auth_req_id as specified in section 7.3 {{CIBA}}.
 
-How this binding is established and then proven is specific to the protocol artefact. For example establishing binding to an authorization_code involves the client instance using client attestation in the authorization request, and proving binding of the authorization_code to the Client Instance involves using the client attestation mechanism to authenticate at the token endpoint using an authorization code grant.
+How this binding is established and then proven is specific to the protocol artifact. For example establishing binding to an authorization_code involves the client instance using client attestation in the authorization request, and proving binding of the authorization_code to the Client Instance involves using the client attestation mechanism to authenticate at the token endpoint using an authorization code grant.
 
 ## Web Server Default Maximum HTTP Header Sizes
 

--- a/draft-ietf-oauth-attestation-based-client-auth.md
+++ b/draft-ietf-oauth-attestation-based-client-auth.md
@@ -538,7 +538,7 @@ Authorization servers issuing a refresh token in response to a token request usi
 
 ## Binding of OAuth protocol artefacts
 
-Authorization servers where possible are RECOMMENDED to bind relevant protocol artefacts to the Client Instance and its associated public key, and NOT just the client as specified in section 6 {{RFC6749}}. Examples of these artefacts include but are not limited to:
+Authorization servers using Attestation-Based Client Authentication are RECOMMENDED to bind relevant protocol artifacts to the Client Instance and its associated public key where possible, and NOT just the client as specified in section 6 {{RFC6749}}. Examples of these artifacts include but are not limited to:
 
 - The authorization_code as specified in section 4.1 {{RFC6749}}.
 - The auth_req_id as specified in section 7.3 {{CIBA}}.

--- a/draft-ietf-oauth-attestation-based-client-auth.md
+++ b/draft-ietf-oauth-attestation-based-client-auth.md
@@ -543,7 +543,7 @@ Authorization servers using Attestation-Based Client Authentication are RECOMMEN
 - The authorization_code as specified in section 4.1 {{RFC6749}}.
 - The auth_req_id as specified in section 7.3 {{CIBA}}.
 
-How this binding is established and then proven is specific to the protocol artifact. For example establishing binding to an authorization_code involves the client instance using client attestation in the authorization request, and proving binding of the authorization_code to the Client Instance involves using the client attestation mechanism to authenticate at the token endpoint using an authorization code grant.
+How this binding is established and then proven is specific to the protocol artifact. For example establishing binding to an authorization_code involves the client instance using client attestation before the user is redirected to the Authorization Endpoint (for example by using PAR, {{RFC9126}}), and proving binding of the authorization_code to the Client Instance involves using the client attestation mechanism to authenticate at the token endpoint when performing the authorization code grant.
 
 ## Web Server Default Maximum HTTP Header Sizes
 

--- a/draft-ietf-oauth-attestation-based-client-auth.md
+++ b/draft-ietf-oauth-attestation-based-client-auth.md
@@ -67,7 +67,6 @@ normative:
     target: "https://www.iana.org/assignments/jose/jose.xhtml#web-signature-encryption-algorithms"
 
 informative:
-  RFC6749:
   RFC9334:
   RFC7523:
   RFC9901:

--- a/draft-ietf-oauth-attestation-based-client-auth.md
+++ b/draft-ietf-oauth-attestation-based-client-auth.md
@@ -70,7 +70,6 @@ informative:
   RFC9901: RFC9901
   ARF:
   	title: "The European Digital Identity Wallet Architecture and Reference Framework"
-  SD-JWT: I-D.ietf-oauth-selective-disclosure-jwt
   CIBA:
     title: OpenID Connect Client-Initiated Backchannel Authentication Flow - Core 1.0
     target: https://openid.net/specs/openid-client-initiated-backchannel-authentication-core-1_0.html

--- a/draft-ietf-oauth-attestation-based-client-auth.md
+++ b/draft-ietf-oauth-attestation-based-client-auth.md
@@ -512,7 +512,7 @@ Authorization servers issuing a refresh token in response to a token request usi
 
 ## Binding of OAuth protocol artifacts
 
-Authorization servers using Attestation-Based Client Authentication are RECOMMENDED to bind relevant protocol artifacts to the Client Instance and its associated public key where possible, and NOT just the client as specified in section 6 {{RFC6749}}. Examples of these artifacts include but are not limited to:
+Authorization servers using Attestation-Based Client Authentication are RECOMMENDED to bind relevant protocol artifacts to the Client Instance and its associated public key where possible, and NOT just the client as specified in {{RFC6749}}. Note that this only applies if Attestation-Based Client Authentication is used as Client Authentication. Examples of these artifacts include but are not limited to:
 
 - The authorization_code as specified in {{Section 4.1 of RFC6749}}.
 - The auth_req_id as specified in section 7.3 {{CIBA}}.

--- a/draft-ietf-oauth-attestation-based-client-auth.md
+++ b/draft-ietf-oauth-attestation-based-client-auth.md
@@ -515,7 +515,7 @@ Authorization servers issuing a refresh token in response to a token request usi
 
 Authorization servers using Attestation-Based Client Authentication are RECOMMENDED to bind relevant protocol artifacts to the Client Instance and its associated public key where possible, and NOT just the client as specified in section 6 {{RFC6749}}. Examples of these artifacts include but are not limited to:
 
-- The authorization_code as specified in section 4.1 {{RFC6749}}.
+- The authorization_code as specified in {{Section 4.1 of RFC6749}}.
 - The auth_req_id as specified in section 7.3 {{CIBA}}.
 
 How this binding is established and then proven is specific to the protocol artifact. For example establishing binding to an authorization_code involves the client instance using client attestation before the user is redirected to the Authorization Endpoint (for example by using PAR, {{RFC9126}}), and proving binding of the authorization_code to the Client Instance involves using the client attestation mechanism to authenticate at the token endpoint when performing the authorization code grant.


### PR DESCRIPTION
Closes #56 
Fixes #114

Looking for feedback on the approach here @panva.

I've opted to not require this behaviour via RECOMMENDED over a MUST this also makes it forward compatible with future OAuth2 extensions that might define new protocol artefacts.